### PR TITLE
dep: upgrade lib-jitsi-meet

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "react-redux": "^7.2.1",
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#15dcc57424cc937290e1963b8eb402c1fcf48ccb"
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#jitsi-meet_5076"
   },
   "devDependencies": {
     "@babel/core": "7.5.5",


### PR DESCRIPTION
we need a working version of lib-jitsi-meet. It seems like we can get reasonable stability and assurance that lib-jitsi-meet is working well while also getting new feature and bugfixes by tracking whatever version of lib-jitsi-meet is used by the latest stable release of [jitsi-meet](https://github.com/jitsi/jitsi-meet/releases/tag/stable%2Fjitsi-meet_5076)