### PR TITLE
feat: makes Vinto respond to users leaving

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,11 @@
-import './App.css';
-import regeneratorRuntime from 'regenerator-runtime';
-import React, { useEffect, useState, useCallback } from 'react';
+import "./App.css";
+import regeneratorRuntime from "regenerator-runtime";
+import React, { useEffect, useState, useCallback } from "react";
 import jitsiConnect, {
   connectLocalTracksToAConference,
-} from '../utils/jitsiConnector';
-import { UIGridLayout } from './uicontainers/';
-import { Conference, Controls, Sidebar } from './components';
+} from "../utils/jitsiConnector";
+import { UIGridLayout } from "./uicontainers/";
+import { Conference, Controls, Sidebar } from "./components";
 
 /**
  * REACT application starts
@@ -15,7 +15,7 @@ import { Conference, Controls, Sidebar } from './components';
  */
 
 const App = () => {
-  console.log('Vinto: RENDERED or RE-RENDERED');
+  console.log("Vinto: RENDERED or RE-RENDERED");
   const [conference, setConference] = useState(null);
   const [tracks, setTracks] = useState({});
 
@@ -28,10 +28,10 @@ const App = () => {
    */
 
   const respondToTrackAdded = (track) => {
-    console.log('Vinto: React app detects TRACK_ADDED');
-    console.log('Vinto: the track that was added --->', track);
-    console.log('Vinto: tracks at this time', tracks);
-    console.log('Vinto: participant ID --->', track.getParticipantId());
+    console.log("Vinto: React app detects TRACK_ADDED");
+    console.log("Vinto: the track that was added --->", track);
+    console.log("Vinto: tracks at this time", tracks);
+    console.log("Vinto: participant ID --->", track.getParticipantId());
 
     const participantId = track.getParticipantId();
     const trackType = track.getType();
@@ -41,7 +41,7 @@ const App = () => {
   };
 
   const respondToTrackRemoved = (track) => {
-    console.log('Vinto: React app detects TRACK_REMOVED');
+    console.log("Vinto: React app detects TRACK_REMOVED");
     // newObj = {};
     // Object.entries(tracks)
     //   .filter(([key, value]) => (key !== track.getParticipantId()))
@@ -49,13 +49,30 @@ const App = () => {
     // setTracks((tracks) => newObj);
   };
 
+  const respondToUserLeft = (id, user) => {
+    console.log(`Vinto: User ${id} Left`, user);
+    setTracks((tracks) => {
+      const updatedTracks = { ...tracks };
+      const videoKey = `${id}-video`;
+      const audioKey = `${id}-audio`;
+      try {
+        delete updatedTracks[videoKey];
+        delete updatedTracks[audioKey];
+        return updatedTracks;
+      } catch (err) {
+        console.log("Vinto: Failed to delete a track -->", err.message);
+      }
+    });
+  };
+
   const connect = async (e) => {
     console.log("Vinto: Let's join a conference now");
     e.preventDefault();
     const { theConference, localVideoTrack } = await jitsiConnect({
-      room: 'some-default-room',
+      room: "some-default-room",
       trackAddedHandler: respondToTrackAdded,
       trackRemovedHandler: respondToTrackRemoved,
+      userLeftHandler: respondToUserLeft,
     });
     // const localVideoTrack = await connectLocalTracksToAConference({
     //   conference: theConference,

--- a/utils/jitsiConnector.js
+++ b/utils/jitsiConnector.js
@@ -58,6 +58,7 @@ const connectToAConference = ({
   connection,
   trackAddedHandler,
   trackRemovedHandler,
+  userLeftHandler,
 }) => {
   // create the local representation of the conference
   const conference = connection.initJitsiConference(room, {});
@@ -78,6 +79,7 @@ const connectToAConference = ({
       JitsiMeetJS.events.conference.TRACK_REMOVED,
       trackRemovedHandler
     );
+    conference.on(JitsiMeetJS.events.conference.USER_LEFT, userLeftHandler);
     // register event handler for successful joining of the conference
     conference.on(JitsiMeetJS.events.conference.CONFERENCE_JOINED, () => {
       resolve({ conference, localVideoTrack });
@@ -122,6 +124,7 @@ const jitsiConnect = async ({
   room,
   trackAddedHandler,
   trackRemovedHandler,
+  userLeftHandler,
 }) => {
   const connection = await connectToAServer({ room });
   console.log("Vinto: Connection object", connection);
@@ -130,6 +133,7 @@ const jitsiConnect = async ({
     connection,
     trackAddedHandler,
     trackRemovedHandler,
+    userLeftHandler,
   });
   conference.addTrack(localVideoTrack);
   console.log("Vinto: Conference object", conference);


### PR DESCRIPTION
Because we don't want leftover rectangles displayed for participants who
have left. The app should re-render and only display participants in the
conference.

HOW it WORKS: respond to USER_LEFT event with respondToUserLeftHandler
which uses setTracks and is defined on the application component and is
passed to jitsiConnector through the connect function.

Closed #40 