### PR TITLE
BUG FIX: Username is now always populated

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -166,7 +166,7 @@ const App = () => {
     <UIGridLayout>
       <Conference tracks={tracks} participantCount={participantCount || 0} />
       <Sidebar />
-      <Controls localTracks={localTracks} />
+      <Controls localTracks={localTracks} name={name} id={id} />
       <button onClick={leave}>
         Leave Conference
       </button>

--- a/src/components/meetingControls/controls.jsx
+++ b/src/components/meetingControls/controls.jsx
@@ -6,7 +6,7 @@ import RaiseHand from './raiseHand';
 import Emoji from './emoji';
 import { controlbarStyle } from '../style';
 
-const Controls = ({ localTracks }) => (
+const Controls = ({ localTracks, name, id }) => (
   <div style={controlbarStyle}>
     <ScreenShare />
     <VideoMute
@@ -15,7 +15,7 @@ const Controls = ({ localTracks }) => (
     <AudioMute
       track={localTracks.filter((track) => track.getType() === 'audio')[0]}
     />
-    <RaiseHand />
+    <RaiseHand name={name} id={id} />
     <Emoji />
   </div>
 );

--- a/src/components/meetingControls/raiseHand.jsx
+++ b/src/components/meetingControls/raiseHand.jsx
@@ -3,15 +3,15 @@ import { useDispatch, useSelector } from 'react-redux';
 import { raiseHand, lowerHand } from '../../store';
 import buttonStyle from '../style';
 
-const RaiseHand = ({ uniqueID }) => {
+const RaiseHand = ({ name, id }) => {
   const [handRaised, setHandRaised] = useState(false);
   const dispatch = useDispatch();
-  const name = useSelector((state) => state.name);
+  // const name = useSelector((state) => state.name);
   const onClick = () => {
     if (handRaised) {
-      dispatch(lowerHand({ uniqueID: name + uniqueID }));
+      dispatch(lowerHand({ uniqueID: name + id }));
     } else {
-      dispatch(raiseHand({ name, uniqueID: name + uniqueID }));
+      dispatch(raiseHand({ name, uniqueID: name + id }));
     }
     setHandRaised(!handRaised);
   };


### PR DESCRIPTION
Closes #65 
- User name was being set after a return statement that was dependent on track being defined at that point in time. it is now in front and guaranteed to show.
- Unique ID has a fallback where if the track is undefined at the time of assignment, a random number is assigned instead.
- Hand raise feature is reconnected to username and unique ID items.