### PR TITLE
BUGFIX: revert participants object to empty object following leaving room

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -72,6 +72,7 @@ const App = () => {
       const updatedParticipants = { ...participants };
       try {
         delete updatedParticipants[id];
+        console.log('Vinto: participant has left')
         return updatedParticipants;
       } catch (err) {
         console.log("Vinto: Failed to delete a participant -->", err.message);
@@ -145,6 +146,7 @@ const App = () => {
       .map((key) => tracks[key])
       .forEach(async (track) => await track.dispose());
     await conference.leave();
+    setParticipants({});
     setConference(null);
     setTracks({});
     setName("");


### PR DESCRIPTION
Closes #70 
the leave () function that is called when a participant leaves the conference was not clearing the participants state. fixed to do so